### PR TITLE
增加音频文件的原信息文件模板，可以用于 Audacity

### DIFF
--- a/audio-file-metadata-template.xml
+++ b/audio-file-metadata-template.xml
@@ -3,6 +3,6 @@
 	<tag name="GENRE" value="开源"/>
 	<tag name="YEAR" value="2022"/>
 	<tag name="ALBUM" value="开源面对面"/>
-	<tag name="TITLE" value="StreamNative 开源岗位"/>
+	<tag name="TITLE" value="S00E00 XXX标题"/>
 	<tag name="ARTIST" value="开源面对面"/>
 </tags>

--- a/audio-file-metadata-template.xml
+++ b/audio-file-metadata-template.xml
@@ -1,0 +1,8 @@
+<tags>
+	<tag name="GitHub" value="https://github.com/opensource-f2f/episode"/>
+	<tag name="GENRE" value="开源"/>
+	<tag name="YEAR" value="2022"/>
+	<tag name="ALBUM" value="开源面对面"/>
+	<tag name="TITLE" value="StreamNative 开源岗位"/>
+	<tag name="ARTIST" value="开源面对面"/>
+</tags>


### PR DESCRIPTION
<img width="534" alt="image" src="https://user-images.githubusercontent.com/1450685/155879582-9e87bbbd-b911-4bbd-a8c9-3a065a0b689f.png">
